### PR TITLE
feat: get theme author profile picture

### DIFF
--- a/src/services/themeService.tsx
+++ b/src/services/themeService.tsx
@@ -16,6 +16,7 @@ const getGitHubThemeData = async (apiTheme: ApiTheme) => {
 	const meta = await (await fetch(metaUrl)).json();
 
 	const contentUrl = `${cdnUrl}/${themeId}/${meta.version}`;
+  
 	// fetch contents
 	const displayFile = 'display.png';
 	const settingsFile = 'settings.json';
@@ -28,7 +29,8 @@ const getGitHubThemeData = async (apiTheme: ApiTheme) => {
 	const cssStylesUrl = `${contentUrl}/${cssStylesFile}`;
 
 	// todo: fetch from github url (can use jsdelivr cache too)
-	const authorImg = '';
+  
+	const authorImg = `https://avatars.githubusercontent.com/${meta.author}`
 
 	// todo: explore whether tags should be stored in database or via meta.json on github
 	const tags = ['beta'];

--- a/src/services/themeService.tsx
+++ b/src/services/themeService.tsx
@@ -30,7 +30,7 @@ const getGitHubThemeData = async (apiTheme: ApiTheme) => {
 
 	// todo: fetch from github url (can use jsdelivr cache too)
   
-	const authorImg = `https://avatars.githubusercontent.com/${meta.author}`
+	const authorImg = `https://avatars.githubusercontent.com/${meta.github}`
 
 	// todo: explore whether tags should be stored in database or via meta.json on github
 	const tags = ['beta'];


### PR DESCRIPTION
#### Description

As of currently, profile pictures of github users aren't stored in the themes github repo, so I accessed github's own cdn at `https://avatars.githubusercontent.com/` .

Closes #28 

#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD (updates related to the CI/CD process)
- [ ] Documentation update (changes to docs/code comments)
- [ ] Chore (miscellaneous tasks that do not fall into the above options)

#### What is the proposed approach?

Using github's own cdn, we can make sure that if a user changes his profile picture our website will be up to date.

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)